### PR TITLE
Fix GLAB_EXPORT_LOGS env var parsing

### DIFF
--- a/new-relic-exporter/global_variables.py
+++ b/new-relic-exporter/global_variables.py
@@ -44,7 +44,7 @@ else:
     
 # Check export logs is set
 if "GLAB_EXPORT_LOGS" in os.environ and os.getenv('GLAB_EXPORT_LOGS').lower() == "false":
-    GLAB_EXPORT_LOGS = os.getenv('GLAB_EXPORT_LOGS')
+    GLAB_EXPORT_LOGS = False
 else:
     GLAB_EXPORT_LOGS = True
         


### PR DESCRIPTION
It was not possible to disable logs export because "false" as a string is truthy