### PR TITLE
Runners specify scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The next image shows a New Relic dashboard with some of the Gitlab metrics youâ€
 | `GLAB_EXPORT_LAST_MINUTES` | The amount past minutes to export data from | True | Integer | 60 |
 | `GLAB_ATTRIBUTES_DROP` | Attributes to drop from logs and spans events | True | List* | None |
 | `GLAB_DIMENSION_METRICS` | Extra dimensional metric attributes to add to each metric | True | List* | NONE Note the following attributes will always be set as dimensions regardless of this setting: status,stage,name |
+| `GLAB_RUNNERS_SCOPE` | Get runners scope : owned, all, active, paused, online, specific, shared (separated by comma) | True | List* | owned |
 | `GLAB_STANDALONE` | Set to True if not running as gitlab pipeline schedule | True | Boolean | False |
-| `GLAB_RUNNERS_SCOPE` | Get runners scope : owned, all, active, paused, online, specific, shared (separated by comma) | True | string | owned |
 | `GLAB_ENVS_DROP` | Extra system environment variables to drop from span attributes | True | List* | Note the following environment variables will always be dropped regardless of this setting: NEW_RELIC_API_KEY,GITLAB_FEATURES,CI_SERVER_TLS_CA_FILE,CI_RUNNER_TAGS,CI_JOB_JWT,CI_JOB_JWT_V1,CI_JOB_JWT_V2,GLAB_TOKEN,GIT_ASKPASS,CI_COMMIT_BEFORE_SHA,CI_BUILD_TOKEN,CI_DEPENDENCY_PROXY_PASSWORD,CI_RUNNER_SHORT_TOKEN,CI_BUILD_BEFORE_SHA,CI_BEFORE_SHA,OTEL_EXPORTER_OTEL_ENDPOINT,GLAB_DIMENSION_METRICS |
 *comma separated
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The next image shows a New Relic dashboard with some of the Gitlab metrics youâ€
 | `GLAB_ATTRIBUTES_DROP` | Attributes to drop from logs and spans events | True | List* | None |
 | `GLAB_DIMENSION_METRICS` | Extra dimensional metric attributes to add to each metric | True | List* | NONE Note the following attributes will always be set as dimensions regardless of this setting: status,stage,name |
 | `GLAB_STANDALONE` | Set to True if not running as gitlab pipeline schedule | True | Boolean | False |
+| `GLAB_RUNNERS_SCOPE` | Get runners scope : owned, all, active, paused, online, specific, shared (separated by comma) | True | string | owned |
 | `GLAB_ENVS_DROP` | Extra system environment variables to drop from span attributes | True | List* | Note the following environment variables will always be dropped regardless of this setting: NEW_RELIC_API_KEY,GITLAB_FEATURES,CI_SERVER_TLS_CA_FILE,CI_RUNNER_TAGS,CI_JOB_JWT,CI_JOB_JWT_V1,CI_JOB_JWT_V2,GLAB_TOKEN,GIT_ASKPASS,CI_COMMIT_BEFORE_SHA,CI_BUILD_TOKEN,CI_DEPENDENCY_PROXY_PASSWORD,CI_RUNNER_SHORT_TOKEN,CI_BUILD_BEFORE_SHA,CI_BEFORE_SHA,OTEL_EXPORTER_OTEL_ENDPOINT,GLAB_DIMENSION_METRICS |
 *comma separated
 

--- a/new-relic-exporter-base/global_variables.py
+++ b/new-relic-exporter-base/global_variables.py
@@ -40,6 +40,7 @@ NEW_RELIC_API_KEY = os.getenv('NEW_RELIC_API_KEY')
 GLAB_TOKEN = os.getenv('GLAB_TOKEN')
 GLAB_EXPORT_PROJECTS_REGEX =".*"
 GLAB_EXPORT_PATHS = ""
+GLAB_RUNNERS_SCOPE = "owned"
 
 # Check export logs is set
 if "GLAB_DORA_METRICS" in os.environ and os.getenv('GLAB_DORA_METRICS').lower() == "true":
@@ -103,6 +104,12 @@ else:
         OTEL_EXPORTER_OTEL_ENDPOINT = "https://otlp.eu01.nr-data.net:4318"
     else:
         OTEL_EXPORTER_OTEL_ENDPOINT = "https://otlp.nr-data.net:4318"
+
+# Check runners scope
+if "GLAB_RUNNERS_SCOPE" in os.environ:
+    # Split comma separated values into a list
+    GLAB_RUNNERS_SCOPE = os.getenv('GLAB_RUNNERS_SCOPE').split(",")
+
         
 #Set variables to use for OTEL metrics and logs exporters
 endpoint="{}".format(OTEL_EXPORTER_OTEL_ENDPOINT)


### PR DESCRIPTION
User can specify the scope for the runners he want to export through the variable `GLAB_RUNNERS_SCOPE`.
Example: 
-  `GLAB_RUNNERS_SCOPE`=all => Export all runners (Access is restricted to users with administrator access)
- `GLAB_RUNNERS_SCOPE`=owned,active => Export owned runners
- `GLAB_RUNNERS_SCOPE`=shared => Export shared runners

(https://python-gitlab.readthedocs.io/en/stable/gl_objects/runners.html)

