### PR TITLE
Export all projects option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The next image shows a New Relic dashboard with some of the Gitlab metrics you�
 | `GLAB_DORA_METRICS` | Export DORA metrics, requires Gitlab ULTIMATE | True | Bool | False |
 | `GLAB_EXPORT_PATHS` | Project paths aka namespace full_path to obtain data from | False | List* | None if running as standalone or CI_PROJECT_ROOT_NAMESPACE if running as pipeline schedule|
 | `GLAB_EXPORT_PROJECTS_REGEX` | Regex to match project names against “.*” for all | False | Boolean | None |
+| `GLAB_EXPORT_ALL` | When True ignore  GLAB_EXPORT_PATHS and GLAB_EXPORT_PROJECTS_REGEX variables and export all projects in any groups or subgroups| False |  Boolean | False |
 | `GLAB_CONVERT_TO_TIMESTAMP` | converts datetime to timestamp | True | Boolean | False |
 | `GLAB_EXPORT_LAST_MINUTES` | The amount past minutes to export data from | True | Integer | 60 |
 | `GLAB_ATTRIBUTES_DROP` | Attributes to drop from logs and spans events | True | List* | None |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The next image shows a New Relic dashboard with some of the Gitlab metrics you�
 | `GLAB_DORA_METRICS` | Export DORA metrics, requires Gitlab ULTIMATE | True | Bool | False |
 | `GLAB_EXPORT_PATHS` | Project paths aka namespace full_path to obtain data from | False | List* | None if running as standalone or CI_PROJECT_ROOT_NAMESPACE if running as pipeline schedule|
 | `GLAB_EXPORT_PROJECTS_REGEX` | Regex to match project names against “.*” for all | False | Boolean | None |
-| `GLAB_EXPORT_PATHS_ALL` | When True ignore GLAB_EXPORT_PATHS variable and export projects matching GLAB_EXPORT_PROJECTS_REGEX in any groups or subgroups| False |  Boolean | False |
+| `GLAB_EXPORT_PATHS_ALL` | When True ignore GLAB_EXPORT_PATHS variable and export projects matching GLAB_EXPORT_PROJECTS_REGEX in any groups or subgroups| True |  Boolean | False |
 | `GLAB_CONVERT_TO_TIMESTAMP` | converts datetime to timestamp | True | Boolean | False |
 | `GLAB_EXPORT_LAST_MINUTES` | The amount past minutes to export data from | True | Integer | 60 |
 | `GLAB_ATTRIBUTES_DROP` | Attributes to drop from logs and spans events | True | List* | None |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The next image shows a New Relic dashboard with some of the Gitlab metrics you�
 | `GLAB_DORA_METRICS` | Export DORA metrics, requires Gitlab ULTIMATE | True | Bool | False |
 | `GLAB_EXPORT_PATHS` | Project paths aka namespace full_path to obtain data from | False | List* | None if running as standalone or CI_PROJECT_ROOT_NAMESPACE if running as pipeline schedule|
 | `GLAB_EXPORT_PROJECTS_REGEX` | Regex to match project names against “.*” for all | False | Boolean | None |
-| `GLAB_EXPORT_ALL` | When True ignore  GLAB_EXPORT_PATHS and GLAB_EXPORT_PROJECTS_REGEX variables and export all projects in any groups or subgroups| False |  Boolean | False |
+| `GLAB_EXPORT_PATHS_ALL` | When True ignore GLAB_EXPORT_PATHS variable and export projects matching GLAB_EXPORT_PROJECTS_REGEX in any groups or subgroups| False |  Boolean | False |
 | `GLAB_CONVERT_TO_TIMESTAMP` | converts datetime to timestamp | True | Boolean | False |
 | `GLAB_EXPORT_LAST_MINUTES` | The amount past minutes to export data from | True | Integer | 60 |
 | `GLAB_ATTRIBUTES_DROP` | Attributes to drop from logs and spans events | True | List* | None |

--- a/new-relic-exporter-base/global_variables.py
+++ b/new-relic-exporter-base/global_variables.py
@@ -40,7 +40,7 @@ NEW_RELIC_API_KEY = os.getenv('NEW_RELIC_API_KEY')
 GLAB_TOKEN = os.getenv('GLAB_TOKEN')
 GLAB_EXPORT_PROJECTS_REGEX =".*"
 GLAB_EXPORT_PATHS = ""
-GLAB_EXPORT_ALL = False
+GLAB_EXPORT_PATHS_ALL = False
 GLAB_RUNNERS_SCOPE = "owned"
 
 # Check export logs is set
@@ -59,8 +59,8 @@ else:
 if "GLAB_EXPORT_PROJECTS_REGEX" in os.environ:
     GLAB_EXPORT_PROJECTS_REGEX = os.getenv('GLAB_EXPORT_PROJECTS_REGEX')
 
-if "GLAB_EXPORT_ALL" in os.environ and os.getenv('GLAB_EXPORT_ALL').lower() == "true":
-    GLAB_EXPORT_ALL = True
+if "GLAB_EXPORT_PATHS_ALL" in os.environ and os.getenv('GLAB_EXPORT_PATHS_ALL').lower() == "true":
+    GLAB_EXPORT_PATHS_ALL = True
 
 # Check base path
 if "GLAB_EXPORT_PATHS" in os.environ:

--- a/new-relic-exporter-base/global_variables.py
+++ b/new-relic-exporter-base/global_variables.py
@@ -40,6 +40,7 @@ NEW_RELIC_API_KEY = os.getenv('NEW_RELIC_API_KEY')
 GLAB_TOKEN = os.getenv('GLAB_TOKEN')
 GLAB_EXPORT_PROJECTS_REGEX =".*"
 GLAB_EXPORT_PATHS = ""
+GLAB_EXPORT_ALL = False
 GLAB_RUNNERS_SCOPE = "owned"
 
 # Check export logs is set
@@ -57,6 +58,9 @@ else:
 # Check if project name regex is set
 if "GLAB_EXPORT_PROJECTS_REGEX" in os.environ:
     GLAB_EXPORT_PROJECTS_REGEX = os.getenv('GLAB_EXPORT_PROJECTS_REGEX')
+
+if "GLAB_EXPORT_ALL" in os.environ and os.getenv('GLAB_EXPORT_ALL').lower() == "true":
+    GLAB_EXPORT_ALL = True
 
 # Check base path
 if "GLAB_EXPORT_PATHS" in os.environ:

--- a/new-relic-metrics-exporter/get_resources.py
+++ b/new-relic-metrics-exporter/get_resources.py
@@ -73,10 +73,10 @@ async def grab_data(project):
         GLAB_SERVICE_NAME = str((project.attributes.get('name_with_namespace'))).lower().replace(" ", "")
         project_json = json.loads(project.to_json())
         # Check if we should export only data for specific groups/projects
-        if paths:
+        if paths or GLAB_EXPORT_ALL:
             for path in paths:          
-                if str(project_json["namespace"]["full_path"]) == (str(path)):
-                    if re.search(str(GLAB_EXPORT_PROJECTS_REGEX), project_json["name"]):
+                if str(project_json["namespace"]["full_path"]) == (str(path)) or GLAB_EXPORT_ALL:
+                    if re.search(str(GLAB_EXPORT_PROJECTS_REGEX), project_json["name"]) or GLAB_EXPORT_ALL:
                         try:
                             print("Project: "+str((project.attributes.get('name_with_namespace'))).lower().replace(" ", "") + " matched configuration, collecting data...")
                             project_id = json.loads(project.to_json())["id"]


### PR DESCRIPTION
User can set `GLAB_EXPORT_PATHS_ALL` to True to export all projects in any group or subgroup matching `GLAB_EXPORT_PROJECTS_REGEX`.

Example:
- `GLAB_EXPORT_PATHS_ALL`=True and `GLAB_EXPORT_PROJECTS_REGEX`=".*" => Will export all the projects that the `GLAB_TOKEN` can access