### PR TITLE
Allow multiple project visibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The next image shows a New Relic dashboard with some of the Gitlab metrics you�
 | `GLAB_TOKEN` | MASKED - Token to access gitlab API | False | String | None |
 | `NEW_RELIC_API_KEY` | MASKED - New Relic License Key | False | String | None |
 | `GLAB_PROJECT_OWNERSHIP` | Project ownership | False | String | True |
-| `GLAB_PROJECT_VISIBILITY` | Project visibility | False | String | private |
+| `GLAB_PROJECT_VISIBILITIES` | Project visibilities (public,private,internal) | False | List* | private |
 | `GLAB_DORA_METRICS` | Export DORA metrics, requires Gitlab ULTIMATE | True | Bool | False |
 | `GLAB_EXPORT_PATHS` | Project paths aka namespace full_path to obtain data from | False | List* | None if running as standalone or CI_PROJECT_ROOT_NAMESPACE if running as pipeline schedule|
 | `GLAB_EXPORT_PROJECTS_REGEX` | Regex to match project names against “.*” for all | False | Boolean | None |

--- a/new-relic-exporter-base/global_variables.py
+++ b/new-relic-exporter-base/global_variables.py
@@ -10,7 +10,7 @@ check_env_vars()
 global GLAB_STANDALONE
 global GLAB_EXPORT_LAST_MINUTES
 global GLAB_PROJECT_OWNERSHIP
-global GLAB_PROJECT_VISIBILITY
+global GLAB_PROJECT_VISIBILITIES
 global GLAB_SERVICE_NAME
 global NEW_RELIC_API_KEY
 global GLAB_TOKEN
@@ -34,7 +34,7 @@ GLAB_EXPORT_LOGS=True
 GLAB_STANDALONE=False
 GLAB_EXPORT_LAST_MINUTES=61
 GLAB_PROJECT_OWNERSHIP=True
-GLAB_PROJECT_VISIBILITY="private"
+GLAB_PROJECT_VISIBILITIES="private"
 GLAB_SERVICE_NAME="gitlab-exporter" # default -> updates dynamically with each project name 
 NEW_RELIC_API_KEY = os.getenv('NEW_RELIC_API_KEY')
 GLAB_TOKEN = os.getenv('GLAB_TOKEN')
@@ -84,8 +84,8 @@ if "GLAB_PROJECT_OWNERSHIP" in os.environ and os.getenv('GLAB_PROJECT_OWNERSHIP'
     GLAB_PROJECT_OWNERSHIP = False  
    
         
-if "GLAB_PROJECT_VISIBILITY" in os.environ:
-    GLAB_PROJECT_VISIBILITY = os.getenv('GLAB_PROJECT_VISIBILITY')
+if "GLAB_PROJECT_VISIBILITIES" in os.environ:
+    GLAB_PROJECT_VISIBILITIES = os.getenv('GLAB_PROJECT_VISIBILITIES').split(",")
     
 # Check if we running as pipeline schedule or standalone mode   
 if "GLAB_STANDALONE" in os.environ and os.getenv('GLAB_STANDALONE').lower() == "true":

--- a/new-relic-exporter-base/otel/__init__.py
+++ b/new-relic-exporter-base/otel/__init__.py
@@ -20,6 +20,8 @@ def create_resource_attributes(atts, GLAB_SERVICE_NAME):
     for att in atts:     
         if att != "name":
             attributes[att]=atts[att]
+        else:
+            attributes["resource.name"]=atts[attr]
     return attributes
 
 def get_logger(endpoint, headers, resource, name):

--- a/new-relic-exporter-base/otel/__init__.py
+++ b/new-relic-exporter-base/otel/__init__.py
@@ -21,7 +21,7 @@ def create_resource_attributes(atts, GLAB_SERVICE_NAME):
         if att != "name":
             attributes[att]=atts[att]
         else:
-            attributes["resource.name"]=atts[attr]
+            attributes["resource.name"]=atts[att]
     return attributes
 
 def get_logger(endpoint, headers, resource, name):

--- a/new-relic-metrics-exporter/main.py
+++ b/new-relic-metrics-exporter/main.py
@@ -13,8 +13,10 @@ def send_to_nr(project):
 
 
 def run():
-    projects = gl.projects.list(owned=GLAB_PROJECT_OWNERSHIP,visibility=GLAB_PROJECT_VISIBILITY,get_all=True)
-    print("Found total of " + str(len(projects)) + " projects using -> OWNED: " + str(GLAB_PROJECT_OWNERSHIP) + " and VISIBILITY: " + str(GLAB_PROJECT_VISIBILITY) + ". \nChecking which ones match provided paths and project regex configuration")  
+    projects = []
+    for visibility in GLAB_PROJECT_VISIBILITIES:
+        projects.extend(gl.projects.list(owned=GLAB_PROJECT_OWNERSHIP,visibility=visibility,get_all=True))
+    print("Found total of " + str(len(projects)) + " projects using -> OWNED: " + str(GLAB_PROJECT_OWNERSHIP) + " and VISIBILITIES: " + str(GLAB_PROJECT_VISIBILITIES) + ". \nChecking which ones match provided paths and project regex configuration")  
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     tasks = [send_to_nr(project) for project in projects]
@@ -27,7 +29,9 @@ def run():
         return "DONE"
     
 if __name__ == '__main__':
-    projects = gl.projects.list(owned=GLAB_PROJECT_OWNERSHIP,visibility=GLAB_PROJECT_VISIBILITY,get_all=True)
+    projects = []
+    for visibility in GLAB_PROJECT_VISIBILITIES:
+        projects.extend(gl.projects.list(owned=GLAB_PROJECT_OWNERSHIP,visibility=visibility,get_all=True))
     if len(projects) == 0:
         print("Nothing to export check your configuration!!!")
     else:


### PR DESCRIPTION
- Allow multiple visibilities when gathering projects
	- `GLAB_PROJECT_VISIBILITY` become `GLAB_PROJECT_VISIBILITIES` and can be set to `public` or/and `private` or/and `internal`
- New attribute `resource.name`
	- Usefull to know the name of a job