### PR TITLE
Fix NameErrors in job_processor and metrics get_resources

### DIFF
--- a/new_relic_exporter/processors/job_processor.py
+++ b/new_relic_exporter/processors/job_processor.py
@@ -258,7 +258,7 @@ class JobProcessor(BaseProcessor):
                         # Send log to New Relic with all attributes
                         # The message field contains the JSON-formatted log with structured data
                         # Use final_attrs for both Resource and extra to ensure no None values
-                        otel_logger = get_structured_logger(endpoint, headers, Resource(attributes=final_attrs), "job_logger")
+                        otel_logger = get_otel_logger(endpoint, headers, Resource(attributes=final_attrs), "job_logger")
                         otel_logger.info(txt, extra=final_attrs)
 
                         count += 1

--- a/new_relic_exporter/processors/job_processor.py
+++ b/new_relic_exporter/processors/job_processor.py
@@ -258,7 +258,7 @@ class JobProcessor(BaseProcessor):
                         # Send log to New Relic with all attributes
                         # The message field contains the JSON-formatted log with structured data
                         # Use final_attrs for both Resource and extra to ensure no None values
-                        otel_logger = get_logger(endpoint, headers, Resource(attributes=final_attrs), "job_logger")
+                        otel_logger = get_structured_logger(endpoint, headers, Resource(attributes=final_attrs), "job_logger")
                         otel_logger.info(txt, extra=final_attrs)
 
                         count += 1

--- a/new_relic_metrics_exporter/get_resources.py
+++ b/new_relic_metrics_exporter/get_resources.py
@@ -1,6 +1,7 @@
 import json
 import os
 import threading
+import pytz
 from datetime import datetime, timedelta, date, timezone
 from typing import Dict, Any
 import zulu

--- a/new_relic_metrics_exporter/get_resources.py
+++ b/new_relic_metrics_exporter/get_resources.py
@@ -1,7 +1,6 @@
 import json
 import os
 import threading
-import pytz
 from datetime import datetime, timedelta, date, timezone
 from typing import Dict, Any
 import zulu
@@ -219,7 +218,7 @@ async def grab_data(project):
                 last_activity = project_json.get("last_activity_at")
                 if last_activity:
                     should_export_project = zulu.parse(last_activity) >= (
-                        datetime.now(timezone.utc).replace(tzinfo=pytz.utc)
+                        datetime.now(timezone.utc)
                         - timedelta(minutes=int(GLAB_EXPORT_LAST_MINUTES))
                     )
                 else:
@@ -510,7 +509,7 @@ def _sync_fetch_releases(project, cutoff):
 async def get_deployments(current_project, project_id, GLAB_SERVICE_NAME):
     global q
     cutoff = (
-        datetime.now(timezone.utc).replace(tzinfo=pytz.utc)
+        datetime.now(timezone.utc)
         - timedelta(minutes=int(GLAB_EXPORT_LAST_MINUTES))
     )
     loop = asyncio.get_running_loop()
@@ -652,7 +651,7 @@ def parse_release(data):
 async def get_releases(current_project, project_id, GLAB_SERVICE_NAME):
     global q
     cutoff = (
-        datetime.now(timezone.utc).replace(tzinfo=pytz.utc)
+        datetime.now(timezone.utc)
         - timedelta(minutes=int(GLAB_EXPORT_LAST_MINUTES))
     )
     loop = asyncio.get_running_loop()
@@ -751,7 +750,7 @@ async def get_pipelines(current_project, project_id, GLAB_SERVICE_NAME):
         "iterator": True,
         "per_page": 100,
         "updated_after": str(
-            datetime.now(timezone.utc).replace(tzinfo=pytz.utc)
+            datetime.now(timezone.utc)
             - timedelta(minutes=int(GLAB_EXPORT_LAST_MINUTES))
         ),
         "order_by": "updated_at",
@@ -853,7 +852,7 @@ def get_jobs(pipelineobject, project_id, GLAB_SERVICE_NAME, pipeline_dict):
     current_pipeline_json = pipeline_dict  # reuse the already-serialized dict
     exclude_jobs = _exclude_jobs
     cutoff = (
-        datetime.now(timezone.utc).replace(tzinfo=pytz.utc)
+        datetime.now(timezone.utc)
         - timedelta(minutes=int(GLAB_EXPORT_LAST_MINUTES))
     )
     for job in jobs:

--- a/shared/requirements.txt
+++ b/shared/requirements.txt
@@ -13,7 +13,6 @@ python-gitlab==8.1.0
 
 # Date/time handling
 pyrfc3339==2.1.0
-pytz==2026.1.post1
 zulu==2.0.1
 
 # Task scheduling


### PR DESCRIPTION
This PR addresses two critical `NameError` exceptions found during deployment that were preventing the correct processing of job logs and the collection of project metrics.

# Related Issues

Fixes #69 (NameError: 'get_logger' is not defined)
Fixes #70 (NameError: 'pytz' is not defined)