### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_push.yaml
+++ b/.github/workflows/build_push.yaml
@@ -6,6 +6,9 @@ on:
   push:
     tags:
       - '*'
+
+permissions:
+  contents: read
     
 jobs:
   login:


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic-experimental/gitlab/security/code-scanning/3](https://github.com/newrelic-experimental/gitlab/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root in `.github/workflows/build_push.yaml`, directly under the workflow triggers (`on:` block) and before `jobs:`.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves existing functionality (checkout needs read access to repository contents) while preventing unintended broader token privileges. No imports, methods, or extra definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
