### PR TITLE
test: improve coverage for issues #69 and #70, fix stale assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If using Kubernetes executors instead, use the below configuration
 
 ```
 image:
-    name: docker.io/dpacheconr/gitlab-exporter:2.2.2
+    name: docker.io/dpacheconr/gitlab-exporter:2.2.3
     entrypoint: [""]
   script:
     - python3 -u /app/main.py
@@ -205,7 +205,7 @@ docker run \
   -e GLAB_EXPORT_PROJECTS_REGEX=".*" \
   -e GLAB_TOKEN="your_gitlab_token" \
   -e NEW_RELIC_API_KEY="your_newrelic_key" \
-  docker.io/dpacheconr/gitlab-metrics-exporter:2.2.2
+  docker.io/dpacheconr/gitlab-metrics-exporter:2.2.3
 ```
 
 ### Option 2: GitLab CI/CD Integration
@@ -216,7 +216,7 @@ Add to your `.gitlab-ci.yml`:
 # For pipeline tracing
 new-relic-export:
   stage: .post
-  image: docker.io/dpacheconr/gitlab-exporter:2.2.2
+  image: docker.io/dpacheconr/gitlab-exporter:2.2.3
   script:
     - python3 -u /app/main.py
   variables:
@@ -226,7 +226,7 @@ new-relic-export:
 
 # For metrics collection (scheduled pipeline)
 new-relic-metrics:
-  image: docker.io/dpacheconr/gitlab-metrics-exporter:2.2.2
+  image: docker.io/dpacheconr/gitlab-metrics-exporter:2.2.3
   script:
     - python3 -u /app/main.py
   variables:
@@ -242,8 +242,8 @@ new-relic-metrics:
 - **New Relic Quickstart**: https://newrelic.com/instant-observability/gitlab
 - **Blog Tutorial**: https://newrelic.com/blog/how-to-relic/monitor-gitlab-with-opentelemetry
 - **Docker Images**: 
-  - `docker.io/dpacheconr/gitlab-exporter:2.2.2`
-  - `docker.io/dpacheconr/gitlab-metrics-exporter:2.2.2`
+  - `docker.io/dpacheconr/gitlab-exporter:2.2.3`
+  - `docker.io/dpacheconr/gitlab-metrics-exporter:2.2.3`
 
 ### Health Monitoring
 
@@ -328,7 +328,7 @@ We encourage your contributions to improve [GitLab Exporters](../../)! Keep in m
 
 ### Development Guidelines
 
-- All code must pass the comprehensive test suite (339 tests)
+- All code must pass the comprehensive test suite (345 tests)
 - Follow the existing code structure and patterns
 - Add tests for new functionality
 - Update documentation for configuration changes

--- a/tests/test_get_resources.py
+++ b/tests/test_get_resources.py
@@ -1,0 +1,213 @@
+"""
+Tests for new_relic_metrics_exporter.get_resources — datetime cutoff logic.
+
+Regression tests for the five functions that filter GitLab resources by a
+rolling time window. Each test freezes datetime.now and verifies that only
+records within GLAB_EXPORT_LAST_MINUTES are queued, and that records outside
+the window are excluded.
+"""
+import json
+import os
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FIXED_NOW = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+WINDOW_MINUTES = 61
+
+# Minimum env vars required by shared.global_variables.check_env_vars on import
+_BASE_ENV = {
+    "GLAB_TOKEN": "glpat-test",
+    "NEW_RELIC_API_KEY": "NRAK-TEST123",
+    "NEW_RELIC_ENDPOINT": "https://otlp.nr-data.net:4317",
+    "GLAB_EXPORT_LAST_MINUTES": str(WINDOW_MINUTES),
+}
+
+# Timestamps relative to FIXED_NOW
+_recent = (FIXED_NOW - timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+_old = (FIXED_NOW - timedelta(minutes=120)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _job_json(created_at):
+    return json.dumps({
+        "id": 1,
+        "name": "build",
+        "stage": "build",
+        "status": "success",
+        "created_at": created_at,
+        "web_url": "https://gitlab.example.com/-/jobs/1",
+        "duration": 60,
+        "ref": "main",
+    })
+
+
+def _deployment_json(created_at):
+    return json.dumps({
+        "id": 1,
+        "status": "success",
+        "created_at": created_at,
+        "environment": {"name": "production"},
+        "deployable": {"name": "deploy"},
+    })
+
+
+def _release_json(released_at):
+    return json.dumps({
+        "tag_name": "v1.0.0",
+        "name": "Release 1.0.0",
+        "released_at": released_at,
+        "description": "test release",
+    })
+
+
+# ---------------------------------------------------------------------------
+# get_jobs
+# ---------------------------------------------------------------------------
+
+@patch.dict(os.environ, _BASE_ENV)
+@patch("new_relic_metrics_exporter.get_resources.GLAB_EXPORT_LAST_MINUTES", WINDOW_MINUTES)
+@patch("new_relic_metrics_exporter.get_resources.datetime")
+@patch("new_relic_metrics_exporter.get_resources.q")
+def test_get_jobs_queues_recent_job(mock_q, mock_dt):
+    from new_relic_metrics_exporter.get_resources import get_jobs
+
+    mock_dt.now.return_value = FIXED_NOW
+
+    recent_job = MagicMock()
+    recent_job.to_json.return_value = _job_json(_recent)
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.jobs.list.return_value = [recent_job]
+
+    get_jobs(mock_pipeline, "proj-1", "test-svc", {})
+
+    assert mock_q.put.call_count == 1
+
+
+@patch.dict(os.environ, _BASE_ENV)
+@patch("new_relic_metrics_exporter.get_resources.GLAB_EXPORT_LAST_MINUTES", WINDOW_MINUTES)
+@patch("new_relic_metrics_exporter.get_resources.datetime")
+@patch("new_relic_metrics_exporter.get_resources.q")
+def test_get_jobs_excludes_old_job(mock_q, mock_dt):
+    from new_relic_metrics_exporter.get_resources import get_jobs
+
+    mock_dt.now.return_value = FIXED_NOW
+
+    old_job = MagicMock()
+    old_job.to_json.return_value = _job_json(_old)
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.jobs.list.return_value = [old_job]
+
+    get_jobs(mock_pipeline, "proj-1", "test-svc", {})
+
+    mock_q.put.assert_not_called()
+
+
+@patch.dict(os.environ, _BASE_ENV)
+@patch("new_relic_metrics_exporter.get_resources.GLAB_EXPORT_LAST_MINUTES", WINDOW_MINUTES)
+@patch("new_relic_metrics_exporter.get_resources.datetime")
+@patch("new_relic_metrics_exporter.get_resources.q")
+def test_get_jobs_stops_at_first_old_job(mock_q, mock_dt):
+    """Jobs are ordered newest-first; once an old job is hit the loop breaks."""
+    from new_relic_metrics_exporter.get_resources import get_jobs
+
+    mock_dt.now.return_value = FIXED_NOW
+
+    recent_job = MagicMock()
+    recent_job.to_json.return_value = _job_json(_recent)
+    old_job = MagicMock()
+    old_job.to_json.return_value = _job_json(_old)
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.jobs.list.return_value = [recent_job, old_job]
+
+    get_jobs(mock_pipeline, "proj-1", "test-svc", {})
+
+    # Only the recent job should be queued
+    assert mock_q.put.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# get_deployments  (async)
+# ---------------------------------------------------------------------------
+
+@patch.dict(os.environ, _BASE_ENV)
+@patch("new_relic_metrics_exporter.get_resources.GLAB_EXPORT_LAST_MINUTES", WINDOW_MINUTES)
+@patch("new_relic_metrics_exporter.get_resources.datetime")
+@patch("new_relic_metrics_exporter.get_resources.q")
+@patch("new_relic_metrics_exporter.get_resources._sync_fetch_deployments")
+def test_get_deployments_passes_correct_cutoff(mock_fetch, mock_q, mock_dt):
+    """get_deployments computes a correct cutoff and passes it to the sync fetcher."""
+    import asyncio
+    from new_relic_metrics_exporter.get_resources import get_deployments
+
+    mock_dt.now.return_value = FIXED_NOW
+    expected_cutoff = FIXED_NOW - timedelta(minutes=WINDOW_MINUTES)
+    # _sync_fetch_deployments returns (matching_jsons, total_fetched, total_api)
+    mock_fetch.return_value = ([], 0, 0)
+
+    asyncio.run(get_deployments(MagicMock(), "proj-1", "test-svc"))
+
+    mock_fetch.assert_called_once()
+    _, called_cutoff = mock_fetch.call_args[0]
+    assert called_cutoff == expected_cutoff
+
+
+# ---------------------------------------------------------------------------
+# get_releases  (async)
+# ---------------------------------------------------------------------------
+
+@patch.dict(os.environ, _BASE_ENV)
+@patch("new_relic_metrics_exporter.get_resources.GLAB_EXPORT_LAST_MINUTES", WINDOW_MINUTES)
+@patch("new_relic_metrics_exporter.get_resources.datetime")
+@patch("new_relic_metrics_exporter.get_resources.q")
+@patch("new_relic_metrics_exporter.get_resources._sync_fetch_releases")
+def test_get_releases_passes_correct_cutoff(mock_fetch, mock_q, mock_dt):
+    """get_releases computes a correct cutoff and passes it to the sync fetcher."""
+    import asyncio
+    from new_relic_metrics_exporter.get_resources import get_releases
+
+    mock_dt.now.return_value = FIXED_NOW
+    expected_cutoff = FIXED_NOW - timedelta(minutes=WINDOW_MINUTES)
+    # _sync_fetch_releases returns (matching_jsons, total_fetched)
+    mock_fetch.return_value = ([], 0)
+
+    asyncio.run(get_releases(MagicMock(), "proj-1", "test-svc"))
+
+    mock_fetch.assert_called_once()
+    _, called_cutoff = mock_fetch.call_args[0]
+    assert called_cutoff == expected_cutoff
+
+
+# ---------------------------------------------------------------------------
+# get_pipelines  (async)
+# ---------------------------------------------------------------------------
+
+@patch.dict(os.environ, _BASE_ENV)
+@patch("new_relic_metrics_exporter.get_resources.GLAB_EXPORT_LAST_MINUTES", WINDOW_MINUTES)
+@patch("new_relic_metrics_exporter.get_resources.datetime")
+@patch("new_relic_metrics_exporter.get_resources.q")
+@patch("new_relic_metrics_exporter.get_resources._sync_fetch_pipelines")
+def test_get_pipelines_updated_after_within_window(mock_fetch, mock_q, mock_dt):
+    """get_pipelines passes an updated_after kwarg whose value represents the cutoff."""
+    import asyncio
+    from new_relic_metrics_exporter.get_resources import get_pipelines
+
+    mock_dt.now.return_value = FIXED_NOW
+    expected_cutoff = FIXED_NOW - timedelta(minutes=WINDOW_MINUTES)
+    # _sync_fetch_pipelines returns (objects, total)
+    mock_fetch.return_value = ([], 0)
+
+    asyncio.run(get_pipelines(MagicMock(), "proj-1", "test-svc"))
+
+    mock_fetch.assert_called_once()
+    # Second positional arg is the pipeline_kwargs dict
+    _, pipeline_kwargs = mock_fetch.call_args[0]
+    assert "updated_after" in pipeline_kwargs
+    assert str(expected_cutoff) in pipeline_kwargs["updated_after"]

--- a/tests/test_global_variables.py
+++ b/tests/test_global_variables.py
@@ -4,7 +4,7 @@ Tests for global variables initialization and configuration.
 
 import pytest
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, ANY
 from queue import Queue
 
 
@@ -117,8 +117,9 @@ class TestGlobalVariables:
             import shared.global_variables as gv
 
             # Verify GitLab client was initialized with custom endpoint
+            # session= is a pre-configured requests.Session injected for connection pooling
             mock_gitlab.assert_called_once_with(
-                url="https://custom-gitlab.com", private_token="test-token"
+                url="https://custom-gitlab.com", private_token="test-token", session=ANY
             )
 
     def test_gitlab_client_initialization_default(self):
@@ -139,7 +140,8 @@ class TestGlobalVariables:
             import shared.global_variables as gv
 
             # Verify GitLab client was initialized with default endpoint
-            mock_gitlab.assert_called_once_with(private_token="test-token")
+            # session= is a pre-configured requests.Session injected for connection pooling
+            mock_gitlab.assert_called_once_with(private_token="test-token", session=ANY)
             assert gv.GLAB_ENDPOINT == "https://gitlab.com/"
 
     def test_otel_endpoint_eu_api_key(self):

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,29 @@
+"""
+Import smoke tests — verify that key modules load without NameError or ImportError.
+
+These tests catch regressions like a missing import or a renamed symbol at module
+scope, which only surface at runtime otherwise (no dedicated unit tests exist for
+these modules). They intentionally do nothing beyond importing.
+"""
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_import_job_processor():
+    from new_relic_exporter.processors.job_processor import JobProcessor  # noqa: F401
+
+
+@patch("shared.otel.get_otel_logger", return_value=MagicMock())
+@patch("shared.otel.get_meter", return_value=MagicMock())
+@patch.dict(os.environ, {
+    "NEW_RELIC_ENDPOINT": "https://otlp.nr-data.net:4317",
+    "NEW_RELIC_API_KEY": "NRAK-TEST123",
+    "GLAB_TOKEN": "glpat-test",
+})
+def test_import_get_resources(mock_meter, mock_logger):
+    import importlib
+    import sys
+    # Force re-import so the test actually exercises the module-level code
+    sys.modules.pop("new_relic_metrics_exporter.get_resources", None)
+    import new_relic_metrics_exporter.get_resources  # noqa: F401

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -222,6 +222,39 @@ class TestJobLogHandling:
         # Verify ANSI codes are processed
         mock_project.jobs.get.assert_called_once()
 
+    @patch("new_relic_exporter.processors.job_processor.get_otel_logger")
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data=b"CI_JOB_STATUS=success CI_PIPELINE_ID=42\n",
+    )
+    def test_handle_job_logs_calls_otel_logger(self, mock_file, mock_get_otel_logger):
+        """Regression test: get_otel_logger must be called when log lines are processed.
+
+        Catches regressions where the function name is changed in the import
+        but not updated at the call site, causing a NameError at runtime.
+        """
+        mock_logger_instance = MagicMock()
+        mock_get_otel_logger.return_value = mock_logger_instance
+
+        mock_config = MagicMock()
+        mock_project = MagicMock()
+        mock_project.jobs.get.return_value = MagicMock()
+
+        processor = JobProcessor(mock_config, mock_project)
+
+        processor.handle_job_logs(
+            job={"id": 12345},
+            endpoint="https://otlp.nr-data.net",
+            headers="api-key=test",
+            resource_attributes={"job.id": "12345", "service.name": "test"},
+            service_name="test-service",
+            error_status=False,
+        )
+
+        mock_get_otel_logger.assert_called()
+        mock_logger_instance.info.assert_called()
+
 
 class TestErrorMessageExtraction:
     """Test suite for error message extraction."""

--- a/tests/test_otel_helpers.py
+++ b/tests/test_otel_helpers.py
@@ -20,67 +20,54 @@ class TestCreateResourceAttributes:
     """Test create_resource_attributes function."""
 
     def test_basic_resource_attributes(self):
-        """Test basic resource attributes creation."""
+        """Test that service.name is always set and only required attributes are promoted."""
         atts = {
-            "key1": "value1",
-            "key2": "value2",
+            "status": "success",   # in _DEFAULT_REQUIRED_ATTRS — should be included
+            "non_required_key": "value",  # not required — should be excluded
         }
         service_name = "test-service"
 
         result = create_resource_attributes(atts, service_name)
 
-        expected = {
-            SERVICE_NAME: "test-service",
-            "key1": "value1",
-            "key2": "value2",
-        }
-
-        assert result == expected
+        assert result[SERVICE_NAME] == "test-service"
+        assert result["status"] == "success"
+        assert "non_required_key" not in result
 
     def test_resource_attributes_with_name_key(self):
-        """Test resource attributes with 'name' key gets converted to 'resource.name'."""
+        """Test that 'name' is not a required attribute and is excluded from resource level."""
         atts = {
             "name": "my-resource",
-            "other_key": "other_value",
+            "status": "success",
         }
         service_name = "test-service"
 
         result = create_resource_attributes(atts, service_name)
 
-        expected = {
-            SERVICE_NAME: "test-service",
-            "resource.name": "my-resource",
-            "other_key": "other_value",
-        }
-
-        assert result == expected
-        assert "name" not in result  # Original 'name' key should not be present
+        # 'name' is not a required resource attribute — it stays at log-record level
+        assert "name" not in result
+        assert "resource.name" not in result
+        assert result["status"] == "success"
+        assert result[SERVICE_NAME] == "test-service"
 
     def test_resource_attributes_filters_none_values(self):
-        """Test that None values are filtered out."""
+        """Test that None, empty, and 'None' string values are filtered even for required attrs."""
         atts = {
-            "valid_key": "valid_value",
-            "none_key": None,
-            "empty_string": "",
-            "none_string": "None",
-            "zero_value": 0,
-            "false_value": False,
+            "status": "success",      # required, valid — included
+            "stage": None,            # required, None — excluded
+            "failure_reason": "",     # required, empty string — excluded
+            "description": "None",   # required, string "None" — excluded
+            "id": "42",               # required, valid — included
         }
         service_name = "test-service"
 
         result = create_resource_attributes(atts, service_name)
 
-        expected = {
-            SERVICE_NAME: "test-service",
-            "valid_key": "valid_value",  # This should be included as it's a valid non-empty string
-            "zero_value": 0,
-            "false_value": False,
-        }
-
-        assert result == expected
-        assert "none_key" not in result
-        assert "empty_string" not in result
-        assert "none_string" not in result
+        assert result[SERVICE_NAME] == "test-service"
+        assert result["status"] == "success"
+        assert result["id"] == "42"
+        assert "stage" not in result
+        assert "failure_reason" not in result
+        assert "description" not in result
 
     def test_resource_attributes_empty_input(self):
         """Test resource attributes with empty input."""
@@ -334,36 +321,33 @@ class TestIntegration:
     """Integration tests for OTEL helper functions."""
 
     def test_create_resource_attributes_integration(self):
-        """Test create_resource_attributes with realistic data."""
+        """Test create_resource_attributes with realistic pipeline data."""
         atts = {
-            "name": "gitlab-pipeline-123",
-            "pipeline_id": "123",
-            "project_id": "456",
-            "status": "success",
-            "ref": "main",
-            "empty_field": "",
-            "null_field": None,
-            "none_string": "None",
+            "name": "gitlab-pipeline-123",  # not required — excluded
+            "pipeline_id": "123",           # required — included
+            "project_id": "456",            # required — included
+            "status": "success",            # required — included
+            "ref": "main",                  # not required — excluded
+            "empty_field": "",              # filtered — excluded
+            "null_field": None,             # filtered — excluded
+            "none_string": "None",          # filtered — excluded
         }
         service_name = "gitlab-exporter"
 
         result = create_resource_attributes(atts, service_name)
 
-        expected = {
-            SERVICE_NAME: "gitlab-exporter",
-            "resource.name": "gitlab-pipeline-123",
-            "pipeline_id": "123",
-            "project_id": "456",
-            "status": "success",
-            "ref": "main",
-        }
-
-        assert result == expected
-        # Ensure filtered fields are not present
+        assert result[SERVICE_NAME] == "gitlab-exporter"
+        assert result["pipeline_id"] == "123"
+        assert result["project_id"] == "456"
+        assert result["status"] == "success"
+        # Non-required attributes stay at log-record level, not resource level
+        assert "ref" not in result
+        assert "name" not in result
+        assert "resource.name" not in result
+        # Filtered fields never appear
         assert "empty_field" not in result
         assert "null_field" not in result
         assert "none_string" not in result
-        assert "name" not in result  # Should be converted to resource.name
 
     @patch("shared.otel.OTLPLogExporter")
     @patch("shared.otel.LoggerProvider")


### PR DESCRIPTION
## Summary

- **Import smoke tests** (`tests/test_imports.py`): bare module imports for `job_processor` and `get_resources` — fail at collection time on any `NameError` or `ImportError` at module scope, catching the class of regression seen in #69 and #70
- **`handle_job_logs` regression test**: adds `test_handle_job_logs_calls_otel_logger` to `test_job_processor.py` — exercises the real function body instead of patching `handle_job_logs` at the object level, explicitly asserting `get_otel_logger` is reached
- **Datetime cutoff tests** (`tests/test_get_resources.py`): covers the rolling-window filter logic in `get_jobs`, `get_deployments`, `get_releases`, and `get_pipelines`
- **Fix stale assertions in `test_global_variables.py`**: `gitlab.Gitlab()` now receives a `session=` argument (pre-configured connection pool); updated assertions to use `ANY` for that arg
- **Fix stale assertions in `test_otel_helpers.py`**: `create_resource_attributes` was refactored to only promote required/whitelisted attributes to resource level; tests updated to assert the new contract
- **Bump version to v2.2.3** and update test count in README

## Test plan

- [ ] `pytest tests/ -q` → 345 passed, 0 failed